### PR TITLE
use install_java_with_overlay

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -30,7 +30,7 @@ fi
 # install JDK
 javaVersion=$(get_jdk_version "${BUILD_DIR}")
 echo -n "-----> Installing OpenJDK ${javaVersion}..."
-install_java ${BUILD_DIR} ${javaVersion}
+install_java_with_overlay ${BUILD_DIR} ${javaVersion}
 jdk_overlay ${BUILD_DIR}
 echo " done"
 


### PR DESCRIPTION
install_java was removed in the heroku jvm https://github.com/heroku/heroku-buildpack-jvm-common/commit/c9b42d21e4692af128a8d779d73fb2db9db121bd

use install_java_with_overlay instead